### PR TITLE
Solução

### DIFF
--- a/PDFConverter.java
+++ b/PDFConverter.java
@@ -1,34 +1,36 @@
 public class ConversorPDF {
-
-    // A aplicação foi projetada para tratar arquivos WORD, temos que cuidar para que
-    // alterações não mudem o comportamento, para que não exista reflexo para clientes
-    // legados
-    public String tipoDocumento = "WORD";
-
     /**
-     * Esse método recebe o como entrada o arquivo que vai ser convertido
+     * Esse método recebe como entrada o arquivo que vai ser convertido
      * para PDF
      *
      * @param bytesArquivo
+	 * @param tipoDocumento
      * @return
      */
-    public byte[] converteParaPDF(byte[] bytesArquivo){
-        if(tipoDocumento.equals("WORD")) {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            documentoWord.save(documentoPDF, SaveFormat.PDF);
-
-            return documentoPDF.toByteArray();
-        } else {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            Workbook workbook = new Workbook(entrada);
-            PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
-            opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            workbook.save(documentoPDF, opcaoSalvar);
-
-            return documentoPDF.toByteArray();
-        }
+    public byte[] converteParaPDF(byte[] bytesArquivo, String tipoDocumento){
+		
+		/*  Verifica se foi passado um arquivo e um tipo de documento, caso não, 
+		 *  não existe necessidade de executar o método, pelo contrário, 
+		 *	caso seja ele resultará uma exception para o usuário.
+		 */
+		if (bytesArquivo != null && tipoDocumento != null){
+			
+			InputStream entrada = new ByteArrayInputStream(bytesArquivo);
+			
+			if(tipoDocumento.equals("WORD")) {
+				com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);
+				ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
+				documentoWord.save(documentoPDF, SaveFormat.PDF);
+				
+			} else if(tipoDocumento.equals("EXCEL")) {
+				Workbook workbook = new Workbook(entrada);
+				PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
+				opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
+				ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
+				workbook.save(documentoPDF, opcaoSalvar);
+			}
+			
+			return documentoPDF.toByteArray();
+		}
     }
 }


### PR DESCRIPTION
- Quais são os problemas que você consegue enxergar aqui?
Resposta: 
1º Problema: Não é uma boa prática de programação deixar uma variável com acesso publico.
2ª Problema: Não checar se o tipoDocumento ou o documento foi devidamente informado, não se deve executar o método caso não tenham sido, caso seja, uma exception será gerada para o usuário.
3º Problema: Não deveria estar hardcode a variável que é usada para verificar o tipo de documento, isto deveria ser um argumento, ocupa menos memória e linhas de código.

- Qual refatoração você propõe?
Porque escolhi o tipo de refatoração efetuado: Deixando tipoDocumento como parâmetro, faz com que seja passado somente mais um parâmetro pelas camadas
do sistema, não precisando definir ou criar processamento em outras partes do sistema para verificar o tipoDocumento escolhido.

Dado o tempo para a tarefa, a refatoração/implementação que eu faria a mais seriam exceptions para tratar erros como "Usuário sem acesso a pasta destino", 
"Usuario sem permissão de criação/alteração" e "Arquivo aberto ou em uso".