### PR TITLE
Refatoração da classe PDFConverter

### DIFF
--- a/PDFConverter.java
+++ b/PDFConverter.java
@@ -13,22 +13,46 @@ public class ConversorPDF {
      * @return
      */
     public byte[] converteParaPDF(byte[] bytesArquivo){
-        if(tipoDocumento.equals("WORD")) {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            documentoWord.save(documentoPDF, SaveFormat.PDF);
-
-            return documentoPDF.toByteArray();
-        } else {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            Workbook workbook = new Workbook(entrada);
-            PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
-            opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            workbook.save(documentoPDF, opcaoSalvar);
-
-            return documentoPDF.toByteArray();
+        if(tipoDocumento.equals("WORD")) {            
+            return wordToPDF(bytesArquivo);
+        } else if(tipoDocumento.equals("EXCEL")) {            
+            return excelToPDF(bytesArquivo);      
+        }else{
+            return null;
         }
+    }
+
+    /**
+     * Esse método recebe o como entrada um arquivo no formato word que vai ser convertido
+     * para PDF
+     * @param bytesArquivo
+     * @return
+     */
+    public byte[] wordToPDF(byte[] bytesArquivo)
+    {
+        InputStream entrada = new ByteArrayInputStream(bytesArquivo);
+        ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();        
+        com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);            
+        documentoWord.save(documentoPDF, SaveFormat.PDF);   
+        
+        return documentoPDF.toByteArray(byte[] bytesArquivo);
+    }
+
+    /**
+     * Esse método recebe o como entrada um arquivo no formato excel que vai ser convertido
+     * para PDF
+     * @param bytesArquivo
+     * @return
+     */
+    public byte[] excelToPDF()
+    {
+        InputStream entrada = new ByteArrayInputStream(bytesArquivo);
+        ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();         
+        Workbook workbook = new Workbook(entrada);
+        PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
+        opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
+        workbook.save(documentoPDF, opcaoSalvar);                
+        
+        return documentoPDF.toByteArray();
     }
 }


### PR DESCRIPTION
Refatorei a classe PDFConverter para deixar mais inteligível para os próximos devs que precisarem dar manutenção no código, ou acrescentar novos métodos de conversão. Fiz isso deixando cada conversão em um método separado.

O problema que eu notei foi que só temos atualmente 2 tipos de conversões, uma de Word para PDF e outra de Excel para PDF, porém o código deixava aberto para qualquer tipo de arquivo que não fosse Word ser convertido pelo método de conversão Excel. Por isso incluí uma nova validação que verifica se o tipo de documento é Excel, se não retorna um valor vazio para a aplicação.