### PR TITLE
Refatoração classe ConversorPDF

### DIFF
--- a/PDFConverter.java
+++ b/PDFConverter.java
@@ -1,34 +1,46 @@
 public class ConversorPDF {
 
-    // A aplica√ß√£o foi projetada para tratar arquivos WORD, temos que cuidar para que
-    // altera√ß√µes n√£o mudem o comportamento, para que n√£o exista reflexo para clientes
-    // legados
-    public String tipoDocumento = "WORD";
+	// A aplicaÁ„o foi projetada para tratar arquivos WORD, temos que cuidar para que
+	// alteraÁıes n„o mudem o comportamento, para que n„o exista reflexo para clientes
+	// legados
+	
+	public ConversorPDF( String tipo ){
+		public String tipoDocumento = tipo;
+	}
+	
+	/**
+	 * Esse mÈtodo recebe o como entrada o arquivo que vai ser convertido
+	 * para PDF
+	 *
+	 * @param bytesArquivo
+	 * @return
+	 */
+	public byte[] converteParaPDF(byte[] bytesArquivo) throws Exception{
+		ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
+		
+		if (tipoDocumento.equals("WORD") || tipoDocumento.equals("EXCEL")){
+			try{
+				if(tipoDocumento.equals("WORD")) {
+					InputStream entrada = new ByteArrayInputStream(bytesArquivo);
+					com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);
+					documentoWord.save(documentoPDF, SaveFormat.PDF);
 
-    /**
-     * Esse m√©todo recebe o como entrada o arquivo que vai ser convertido
-     * para PDF
-     *
-     * @param bytesArquivo
-     * @return
-     */
-    public byte[] converteParaPDF(byte[] bytesArquivo){
-        if(tipoDocumento.equals("WORD")) {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            com.aspose.words.Document documentoWord = new com.aspose.words.Document(entrada);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            documentoWord.save(documentoPDF, SaveFormat.PDF);
+					return documentoPDF.toByteArray();
+				} else {
+					InputStream entrada = new ByteArrayInputStream(bytesArquivo);
+					Workbook workbook = new Workbook(entrada);
+					PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
+					opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
+					workbook.save(documentoPDF, opcaoSalvar);
 
-            return documentoPDF.toByteArray();
-        } else {
-            InputStream entrada = new ByteArrayInputStream(bytesArquivo);
-            Workbook workbook = new Workbook(entrada);
-            PdfSaveOptions opcaoSalvar = new PdfSaveOptions();
-            opcaoSalvar.setCompliance(PdfCompliance.PDF_A_1_B);
-            ByteArrayOutputStream documentoPDF = new ByteArrayOutputStream();
-            workbook.save(documentoPDF, opcaoSalvar);
-
-            return documentoPDF.toByteArray();
-        }
-    }
+					return documentoPDF.toByteArray();
+				}
+			}catch(Exception e){
+				System.out.println("Erro ao converter o arquivo do tipo" + tipoDocumento);
+			}
+		} else {
+			System.out.println("Tipo de arquivo n„o permitido:" + tipoDocumento);
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
Primeiro problema que identifiquei foi a inicialização da variável tipoDocumento, não permitindo outro tipo senão o WORD. Para isso, criei um construtor com para receber o tipoDocumento que o usuário vai realizar a conversão.

Segundo problema era na validação do tipoDocumento. Se fosse WORD, ok. Caso não, daria problema caso não fosse EXCEL. Quanto a isso foi feito a verificação dos dois tipos permitidos no momento. Caso não seja nenhum dos dois arquivos retorna um mensagem de erro.

Terceiro problema seria no processo de conversão. Não existia tratamento caso houvesse erro. Para isso foi utilizado um try/catch.

No caso de futuras implementações, basta somente adicionar a extensão na condição de verificação do tipoDocumento e seu respectivo código de conversão no seu laço.